### PR TITLE
Updates ngs_PIPELINE to v2.2

### DIFF
--- a/ngs_PIPELINE.sh
+++ b/ngs_PIPELINE.sh
@@ -38,7 +38,7 @@ ngsHelp_PIPELINE() {
 	echo -e "OPTIONS:"
 	echo -e "\t-i - parent directory containing subdirectory with compressed fastq files (default: ./raw). This is the parent directory of the sample-specific directory. The sampleID will be used to complete the directory path (ie inputDir/sampleID)."
 	echo -e "\t-o - directory containing subdirectory with analysis files (default: ./analyzed). This is the parent directory of the sample-specific directory. The sampleID will be used to complete the directory path (ie outputDir/sampleID)."
-	echo -e "\t-t type - RNASeq, or WGS (Whole Genome Sequencing) (default: RNASeq)."
+	echo -e "\t-t type - RNASeq, RNASeq_BC, or WGS (Whole Genome Sequencing) (default: RNASeq). The RNASeq_BC adds barcode selection and trimming to the standard RNASeq pipeline."
 	echo -e "\t-l readLength - read length (default = 100). If paired end then this is the length of one mate. Used to determine blast e-values and star library length."
 	echo -e "\t-p numProc - number of cpu to use."
 	echo -e "\t-s species - species from repository: $REPO_LOCATION."
@@ -49,6 +49,7 @@ ngsHelp_PIPELINE() {
 	echo -e "\t-stranded - data comes from stranded library preparation. Reads will only be counted if they align on the same strand as annotated features. Default is unstranded."
 	echo -e "\t-lines_sines - quantify LINE and SINE elements, separately from other features. "
 	echo -e "\t-chgrp group - change the unix group of a sample and it's data before syncing to the repo. Default is no change."
+	echo -e "\t-small - abreviated pipeline that keeps fewer large output files. The trim output files, the position sorted STAR output, and the STAR unmapped reads files are all excluded.\n"
 	echo -e "This will process sequencing data using either an RNASeq or WGS (Whole Genome Sequencing) pipeline. For RNASeq the modules used are: init, fastqc, blast, trim, star, verse, post, and rsync. For WGS the modules used are: init, fastqc, blast, trim, bowtie, SPAdes, post, and rsync. See individual modules for documentation."
 }
 
@@ -64,9 +65,10 @@ ngsLocal_PIPELINE_LINES_SINES=""
 ngsLocal_PIPELINE_ID_ATTR="gene_id"
 ngsLocal_PIPELINE_STRANDED=""
 ngsLocal_PIPELINE_GROUP=""
-ngsLocal_PIPELINE_SPIKE="ERCC"
+small=false
+noinit=false
 
-##########################################################################################
+#########################################################################################
 # PROCESSING COMMAND LINE ARGUMENTS
 # PIPELINE args: -i value, -o value, -t value, -p value, -s value, -se (optional), sampleID
 ##########################################################################################
@@ -74,7 +76,7 @@ ngsLocal_PIPELINE_SPIKE="ERCC"
 ngsArgs_PIPELINE() {
 	if [ $# -lt 5 ]; then printHelp "PIPELINE"; fi
 
-	ngsLocal_PIPELINE_INITIAL_ARGS="$@" 
+	ngsLocal_PIPELINE_INITIAL_ARGS="$@" #needed to recurse for multi-barcode samples
 
 	# getopts doesn't allow for optional arguments so handle them manually
 	while true; do
@@ -106,9 +108,6 @@ ngsArgs_PIPELINE() {
 			-f) ngsLocal_PIPELINE_FEATURES=$2
 				shift; shift;
 				;;
-			-k) ngsLocal_PIPELINE_SPIKE=$2
-				shift; shift;
-				;;
 			-b) ngsLocal_PIPELINE_BC=$2
 				shift; shift;
 				;;
@@ -123,6 +122,12 @@ ngsArgs_PIPELINE() {
 				;;
 			-chgrp) ngsLocal_PIPELINE_GROUP="-g $2"
 				shift; shift;
+				;;
+			-small) small=true
+				shift;
+				;;
+			-noinit) noinit=true
+				shift;
 				;;
 			-*) printf "Illegal option: '%s'\n" "$1"
 				printHelp $COMMAND
@@ -167,18 +172,20 @@ ngsCmd_PIPELINE() {
 	# to call ngsArgs_INIT() to update the value, prior to calling
 	# ngsCmd_INIT().
 
-	ngsArgs_INIT -i $RAW $SAMPLE
-	ngsCmd_INIT
+	if ! $noinit; then
+	    ngsArgs_INIT -i $RAW $SAMPLE
+	    ngsCmd_INIT
+	fi
 	ngsCmd_FASTQC
-    ########################################################
+   ########################################################
 
-	if [[ "$ngsLocal_PIPELINE_TYPE" = "RNASeq" ]]; then
+      if [[ "$ngsLocal_PIPELINE_TYPE" = "RNASeq" ]]; then
 	    ngsArgs_BLAST -l $READ_LENGTH -k TATAGTGAGT -p $NUMCPU -s $SPECIES $SAMPLE
 	    ngsCmd_BLAST
 	    ngsArgs_TRIM -t $NUMCPU -m 20 -q 53 -rAT 26 -rN -c $ngsLocal_CONTAM_NAME $SAMPLE
 	    ngsCmd_TRIM
-	# Need different args to run FastQC on the trimmed data, so adjust
-	# args by calling ngsArgs_FASTQC() prior to running ngsCmd_FASTQC().
+	    # Need different args to run FastQC on the trimmed data, so adjust
+	    # args by calling ngsArgs_FASTQC() prior to running ngsCmd_FASTQC().
 	    ngsArgs_FASTQC -i trim -o fastqc.trim $SAMPLE
 	    ngsCmd_FASTQC
 	    ngsCmd_STAR
@@ -187,41 +194,66 @@ ngsCmd_PIPELINE() {
 	    ngsLocal_PIPELINE_check_readCnts
 	    #ngsCmd_BLASTDB
                           
+	elif [[ "$ngsLocal_PIPELINE_TYPE" = "RNASeq_BC" ]]; then
+	    ngsArgs_BLAST -l $READ_LENGTH -k TATAGTGAGT -p $NUMCPU -s $SPECIES $SAMPLE
+	    ngsCmd_BLAST
+	    ngsArgs_BARCODE -b $ngsLocal_PIPELINE_BC $SAMPLE
+	    ngsCmd_BARCODE
+	    ngsArgs_TRIM -i barcode.trim -t $NUMCPU -rPoly -rN -m 10 -c $ngsLocal_CONTAM_NAME $SAMPLE
+	    ngsCmd_TRIM
+	    ngsArgs_FASTQC -i barcode.trim -o fastqc.barcode $SAMPLE
+	    ngsCmd_FASTQC
+	    ngsCmd_STAR
+	    ngsArgs_VERSE $ngsLocal_PIPELINE_STRANDED $ngsLocal_PIPELINE_LINES_SINES -l $ngsLocal_PIPELINE_FEATURES -id $ngsLocal_PIPELINE_ID_ATTR -p $NUMCPU -s $SPECIES $SAMPLE
+	    ngsCmd_VERSE
+	    ngsLocal_PIPELINE_check_readCnts
+	    ngsArgs_POST -i barcode.trim $SAMPLE
+	    ngsCmd_POST
+	    ngsArgs_POST -i trim $SAMPLE  #Args has to be called to reset prior call
+
 	elif [[ "$ngsLocal_PIPELINE_TYPE" = "WGS" ]]; then
-		ngsArgs_BLAST -l $READ_LENGTH -k TATAGTGAGT -p $NUMCPU -s $SPECIES $SAMPLE
-		ngsCmd_BLAST
-		# disable poly-A/T trimming for WGS
-		if [[ $ngsLocal_CONTAM_NAME == "contaminants.fa" ]]; then
-		    # If the contaminants file is still the default, change it to the WGS default. 
-		    ngsLocal_CONTAM_NAME="contaminantsWGS.fa"
-		fi
-		ngsArgs_TRIM -m 19 -rAT 0 -rN -c contaminantsWGS.fa $SAMPLE
-		ngsCmd_TRIM
-		ngsArgs_FASTQC -i trim -o fastqc.trim $SAMPLE
-		ngsCmd_FASTQC
-		ngsCmd_BOWTIE
-		ngsCmd_SNP
-		ngsCmd_SPADES
-		ngsArgs_POST -i bowtie $SAMPLE
-		ngsCmd_POST
-		ngsArgs_POST -i bowtie/SE_mapping $SAMPLE
-		ngsCmd_POST
-		#ngsArgs_POST -i trim $SAMPLE  #Args has to be called to reset prior call
+	    ngsArgs_BLAST -l $READ_LENGTH -k TATAGTGAGT -p $NUMCPU -s $SPECIES $SAMPLE
+	    ngsCmd_BLAST
+	    # disable poly-A/T trimming for WGS
+	    if [[ $ngsLocal_CONTAM_NAME == "contaminants.fa" ]]; then
+		# If the contaminants file is still the default, change it to the WGS default. 
+		ngsLocal_CONTAM_NAME="contaminantsWGS.fa"
+	    fi
+	    ngsArgs_TRIM -m 19 -rAT 0 -rN -c contaminantsWGS.fa $SAMPLE
+	    ngsCmd_TRIM
+	    ngsArgs_FASTQC -i trim -o fastqc.trim $SAMPLE
+	    ngsCmd_FASTQC
+	    ngsCmd_BOWTIE
+	    ngsCmd_SNP
+	    ngsCmd_SPADES
+	    ngsArgs_POST -i bowtie $SAMPLE
+	    ngsCmd_POST
+	    ngsArgs_POST -i bowtie/SE_mapping $SAMPLE
+	    ngsCmd_POST
+	    #ngsArgs_POST -i trim $SAMPLE  #Args has to be called to reset prior call
 
 	else
-		prnCmd "ERROR: Invalid PIPELINE type $ngsLocal_PIPELINE_TYPE. Valid options are 'RNASeq' and 'WGS'."
+	    prnCmd "ERROR: Invalid PIPELINE type $ngsLocal_PIPELINE_TYPE. Valid options are 'RNASeq' and 'WGS'."
 	fi
 
 	########################################################
 	### The modules below are included in all pipelines. ###
 
 	# compress the trimmed files
-	ngsArgs_POST -i trim $ngsLocal_PIPELINE_GROUP $SAMPLE #Change group to repo-admin before syncing. Uses -i trim to reset any previous calls to args
-	ngsCmd_POST
-	# OutputDir defaults to $ANALYZED which is hardcoded in
-	# ngs.sh, just like inputDir and $RAW.
-	ngsArgs_RSYNC -o $ANALYZED $SAMPLE
-	ngsCmd_RSYNC
+	if $small; then
+	    prnCmd "chgrp -R $ngsLocal_PIPELINE_GROUP $SAMPLE"
+	    chgrp -R repo-admin $SAMPLE
+
+	    prnCmd "rsync -avh --stats --exclude "init" --exclude "unaligned_*.fq" --exclude "Unmapped.out.*" $SAMPLE $ANALYZED/"
+	    rsync -avh --stats --exclude "init" --exclude "unaligned_*.fq" --exclude "Unmapped.out.*" $SAMPLE $ANALYZED/
+	else
+	    ngsArgs_POST -i trim $ngsLocal_PIPELINE_GROUP $SAMPLE #Change group to repo-admin before syncing. Uses -i trim to reset any previous calls to args
+	    ngsCmd_POST
+	    # OutputDir defaults to $ANALYZED which is hardcoded in
+	    # ngs.sh, just like inputDir and $RAW.
+	    ngsArgs_RSYNC -o $ANALYZED $SAMPLE
+	    ngsCmd_RSYNC
+	fi
 	########################################################
 
 	if $SE; then prnCmd "# FINISHED: SINGLE-END, $ngsLocal_PIPELINE_TYPE PIPELINE"
@@ -230,7 +262,7 @@ ngsCmd_PIPELINE() {
 
 ngsLocal_PIPELINE_check_readCnts() {
     local starPairs=$(grep "Uniquely mapped reads number" $SAMPLE/star/$SAMPLE.star.stats.txt | cut -f2)
-    local versePairs=$(grep "TotalReadPairs" $SAMPLE/verse/$SAMPLE.verse.summary.txt | cut -f2)
+    local versePairs=$(grep "TotalRead" $SAMPLE/verse/$SAMPLE.verse.summary.txt | cut -f2)
 
     if [[ $starPairs -ne $versePairs ]]; then
 	prnError "Star reports $starPairs unique mapped pairs, but Verse reports $versePairs input pairs"


### PR DESCRIPTION
* Adds a seq type for selection by internal barcode
* Adds option to skip init phase for re-running samples
* Adds an option for a pipeline that keeps a smaller, less
comprehensive set of output files
* Changes group of final sync'd output to 'repo-admin'